### PR TITLE
Add roswell as new common lisp implementation manager

### DIFF
--- a/roswell
+++ b/roswell
@@ -1,0 +1,1 @@
+install_env https://github.com/windymelt/anyenv-roswell-wrapper.git


### PR DESCRIPTION
[Roswell](https://github.com/roswell/roswell) is an implementation/package manager for common lisp.

I wrote a wrapper which helps installing and building roswell on anyenv way.

I'd like to add roswell as default install for anyenv.