### PR TITLE
Update crenv repo

### DIFF
--- a/crenv
+++ b/crenv
@@ -1,2 +1,2 @@
-install_env https://github.com/pine/crenv.git
-install_plugin crystal-build https://github.com/pine/crystal-build.git
+install_env https://github.com/crenv/crenv.git
+install_plugin crystal-build https://github.com/crenv/crystal-build.git


### PR DESCRIPTION
While technically pine/*.git redirects to the crenv GitHub org for now, we should correct it proactively.