### PR TITLE
Remove nodenv-default-packages from install_plugin of nodenv

### DIFF
--- a/nodenv
+++ b/nodenv
@@ -1,4 +1,3 @@
 install_env https://github.com/nodenv/nodenv.git
 install_plugin node-build https://github.com/nodenv/node-build.git
-install_plugin nodenv-default-packages https://github.com/nodenv/nodenv-default-packages.git
 install_plugin nodenv-vars https://github.com/nodenv/nodenv-vars.git


### PR DESCRIPTION
I love anyenv 💘 

`nodenv install` has error with `nodenv: default-packages file not found` , I use anyenv with [itamae-plugin-recipe-anyenv](https://github.com/surume/itamae-plugin-recipe-anyenv).
Because of this error, nodenv-default-packages requires `$(nodenvroot)/default-packages` file.
But anyenv doese not create `$(nodenvroot)/default-packages` file.
nodenv-default-packages recommends create default-packages by hand.

`nodenv install` can install nodejs. But command is fail.
Because provisioninng tools(ex chef, itamae) can not use anyenv.

Please check PR.