### PR TITLE
Support kubectlenv

### DIFF
--- a/kubectlenv
+++ b/kubectlenv
@@ -1,0 +1,1 @@
+install_env https://github.com/PatTheSilent/kubectlenv.git


### PR DESCRIPTION
Hey,

I'd like to add support for [`kubectlenv`](https://github.com/PatTheSilent/kubectlenv), which is a version manager for [`kubectl`](https://kubernetes.io/docs/reference/kubectl/kubectl/).