### PR TITLE
Support tgenv

### DIFF
--- a/tgenv
+++ b/tgenv
@@ -1,0 +1,1 @@
+install_env https://github.com/cunymatthieu/tgenv.git


### PR DESCRIPTION
Hi,

I'd like to add [tgenv](https://github.com/cunymatthieu/tgenv) support for [Terragrunt](https://github.com/gruntwork-io/terragrunt).

Following is a quote from README of Terragrunt.

> Terragrunt is a thin wrapper for Terraform that provides extra tools for keeping your Terraform configurations DRY, working with multiple Terraform modules, and managing remote state.

As mentioned in README, tgenv is inspired by tfenv, and has similar options to tfenv.